### PR TITLE
fix: add missing click dependency to setup metadata

### DIFF
--- a/install_mac.py
+++ b/install_mac.py
@@ -7,6 +7,7 @@
 #   "typer",
 #   "coloredlogs",
 #   "inquirer3",
+#   "click<8.2.0",
 # ]
 # ///
 


### PR DESCRIPTION
## Description
This PR fixes an environment resolution bug by explicitly adding `click` to the project's dependencies and locking down version compatibility to prevent a runtime `AttributeError`.

## The Problem 
When executing this script inside a clean, isolated environment (such as via `uv run`), the script failed in two stages:

1. **Missing Module:** The script immediately threw a `ModuleNotFoundError: No module named 'click'` because `click` was completely missing from the declared dependencies layout.
2. **Version Mismatch AttributeError:** After manually introducing `click`, the environment implicitly fetched the latest unconstrained version of Click. This introduced a breaking change with the current `typer` implementation, throwing the following error during initialization:
   ```text
   AttributeError: 'Context' object has no attribute '_param_default_explicit'