### PR TITLE
Set $THEOS environment variable in .xonshrc

### DIFF
--- a/.xonshrc
+++ b/.xonshrc
@@ -42,6 +42,7 @@ CUSTOM_RC = Path('~/.myrc').expanduser()
 
 # -- ENV
 XSH.env['WORKSETUP_ROOT'] = '~/dev'
+XSH.env['THEOS'] = str(Path('~/theos').expanduser())
 # XSH.env['DEVICE_SSH_PORT'] = 4444
 XSH.env['PROMPT'] = '{env_name}{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} {cwd}{branch_color}{curr_branch: {}}{RESET} {BOLD_BLUE}{prompt_end}{RESET} '
 XSH.env['PATH'] = [


### PR DESCRIPTION
Adds $THEOS to the xonsh environment so Theos (https://github.com/theos/theos) can be installed/used — the official installer can't auto-configure xonsh and requires this to be set manually.